### PR TITLE
ARM64 fixes

### DIFF
--- a/src/Pool.cpp
+++ b/src/Pool.cpp
@@ -55,7 +55,6 @@ void* Pool::getCommonHandler(void* originalFunction, size_t uniqueIndex, ptrdiff
 
 	if (s_handlerList.size() <= uniqueIndex || s_handlerList[uniqueIndex] == nullptr) {
 		s_handlerList.resize(uniqueIndex + 1, nullptr);
-		bool shouldCreateTrampoline = false;
 
 		std::unique_lock lock(m_handlerMutex);
 
@@ -66,18 +65,15 @@ void* Pool::getCommonHandler(void* originalFunction, size_t uniqueIndex, ptrdiff
 				.m_abstract = AbstractFunction::from<void(void)>()
 			});
 			m_handlers.emplace(handle, std::move(handler));
-			shouldCreateTrampoline = true;
 		}
 		s_handlerList[uniqueIndex] = m_handlers[handle].get();
 
-		if (shouldCreateTrampoline) {
-			auto trampoline = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(commonHandler) + trampolineOffset);
+		auto trampoline = reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(commonHandler) + trampolineOffset);
 
-			auto metadata = HookMetadata{
-				.m_priority = INT_MAX,
-			};
-			s_handlerList[uniqueIndex]->createHook(trampoline, metadata);
-		}
+		auto metadata = HookMetadata{
+			.m_priority = INT_MAX,
+		};
+		s_handlerList[uniqueIndex]->createHook(trampoline, metadata);
 	}
 
 	auto handler = s_handlerList[uniqueIndex];
@@ -103,7 +99,7 @@ geode::Result<> Pool::disableRuntimeIntervening(void* commonHandlerSpace) {
 	GEODE_UNWRAP(Target::get().writeMemory(commonHandlerSpace, &handler, sizeof(handler)));
 
 	m_runtimeInterveningDisabled = true;
-	
+
 	return geode::Ok();
 }
 

--- a/src/assembler/ArmV8Assembler.cpp
+++ b/src/assembler/ArmV8Assembler.cpp
@@ -193,13 +193,13 @@ void ArmV8Assembler::tbnz(ArmV8Register reg, int32_t bit, int32_t imm) {
     this->write32(0x37000000 | literalShifted | bitShifted | val(reg));
 }
 
-void ArmV8Assembler::cbz(ArmV8Register reg, int32_t imm) {
+void ArmV8Assembler::cbz(ArmV8Register reg, int32_t imm, bool is64Bit) {
     const auto literalShifted = ((imm >> 2) & 0x3FFFF) << 5;
-    this->write32(0xb4000000 | literalShifted | val(reg));
+    this->write32((is64Bit ? 0xb4000000 : 0x34000000) | literalShifted | val(reg));
 }
-void ArmV8Assembler::cbnz(ArmV8Register reg, int32_t imm) {
+void ArmV8Assembler::cbnz(ArmV8Register reg, int32_t imm, bool is64Bit) {
     const auto literalShifted = ((imm >> 2) & 0x3FFFF) << 5;
-    this->write32(0xb5000000 | literalShifted | val(reg));
+    this->write32((is64Bit ? 0xb5000000 : 0x35000000) | literalShifted | val(reg));
 }
 
 void ArmV8Assembler::bcond(int32_t imm, uint32_t cond) {

--- a/src/assembler/ArmV8Assembler.hpp
+++ b/src/assembler/ArmV8Assembler.hpp
@@ -115,8 +115,8 @@ namespace tulip::hook {
 		void tbz(ArmV8Register reg, int32_t bit, int32_t imm);
 		void tbnz(ArmV8Register reg, int32_t bit, int32_t imm);
 
-		void cbz(ArmV8Register reg, int32_t imm);
-		void cbnz(ArmV8Register reg, int32_t imm);
+		void cbz(ArmV8Register reg, int32_t imm, bool is64Bit = true);
+		void cbnz(ArmV8Register reg, int32_t imm, bool is64Bit = true);
 
 		void bcond(int32_t imm, uint32_t cond);
 
@@ -125,5 +125,5 @@ namespace tulip::hook {
 		void push(ArmV8RegisterArray const& array);
 		void pop(ArmV8RegisterArray const& array);
 	};
-	
+
 }

--- a/src/generator/ArmV8Generator.cpp
+++ b/src/generator/ArmV8Generator.cpp
@@ -297,17 +297,19 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::CBZ: {
+				bool sf = (ins->m_rawInstruction >> 31) & 1;
+
 				if (canDeltaRange(newOffset, 33)) {
 					a.adrp(X16, alignedCallback - alignedAddr);
 					a.add(X16, X16, callback & 0xFFF);
-					a.cbz(ins->m_src1, 8);
+					a.cbz(ins->m_src1, 8, sf);
 					a.b("jump-" + idxLabel);
 					a.br(X16);
 
 					a.label("jump-" + idxLabel);
 				} else {
 					a.ldr(X16, "literal-" + idxLabel);
-					a.cbz(ins->m_src1, 8);
+					a.cbz(ins->m_src1, 8, sf);
 					a.b("jump-" + idxLabel);
 					a.br(X16);
 
@@ -319,17 +321,19 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::CBNZ: {
+				bool sf = (ins->m_rawInstruction >> 31) & 1;
+
 				if (canDeltaRange(newOffset, 33)) {
 					a.adrp(X16, alignedCallback - alignedAddr);
 					a.add(X16, X16, callback & 0xFFF);
-					a.cbnz(ins->m_src1, 8);
+					a.cbnz(ins->m_src1, 8, sf);
 					a.b("jump-" + idxLabel);
 					a.br(X16);
 
 					a.label("jump-" + idxLabel);
 				} else {
 					a.ldr(X16, "literal-" + idxLabel);
-					a.cbnz(ins->m_src1, 8);
+					a.cbnz(ins->m_src1, 8, sf);
 					a.b("jump-" + idxLabel);
 					a.br(X16);
 

--- a/src/generator/ArmV8Generator.cpp
+++ b/src/generator/ArmV8Generator.cpp
@@ -187,8 +187,16 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 			return ss.str();
 		});
 
+		auto shouldSkipBranch = [&] {
+			bool should = ins->m_literal >= address && ins->m_literal < address + targetSize;
+			if (should) a.write32(ins->m_rawInstruction);
+			return should;
+		};
+
 		switch (ins->m_type) {
 			case ArmV8InstructionType::B: {
+				if (shouldSkipBranch()) break;
+
 				if (canDeltaRange(newOffset, 28)) {
 					a.b(newOffset);
 				} else if (canDeltaRange(newOffset, 33)) {
@@ -205,6 +213,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::BL: {
+				if (shouldSkipBranch()) break;
+
 				if (canDeltaRange(newOffset, 28)) {
 					a.bl(newOffset);
 				} else if (canDeltaRange(newOffset, 33)) {
@@ -274,6 +284,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::B_Cond: {
+				if (shouldSkipBranch()) break;
+
 				if (canDeltaRange(newOffset, 33)) {
 					a.adrp(X16, alignedCallback - alignedAddr);
 					a.add(X16, X16, callback & 0xFFF);
@@ -297,6 +309,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::CBZ: {
+				if (shouldSkipBranch()) break;
+
 				bool sf = (ins->m_rawInstruction >> 31) & 1;
 
 				if (canDeltaRange(newOffset, 33)) {
@@ -321,6 +335,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::CBNZ: {
+				if (shouldSkipBranch()) break;
+
 				bool sf = (ins->m_rawInstruction >> 31) & 1;
 
 				if (canDeltaRange(newOffset, 33)) {
@@ -345,6 +361,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::TBZ: {
+				if (shouldSkipBranch()) break;
+
 				if (canDeltaRange(newOffset, 33)) {
 					a.adrp(X16, alignedCallback - alignedAddr);
 					a.add(X16, X16, callback & 0xFFF);
@@ -369,6 +387,8 @@ geode::Result<BaseGenerator::RelocateReturn> ArmV8Generator::relocatedBytes(int6
 				break;
 			}
 			case ArmV8InstructionType::TBNZ: {
+				if (shouldSkipBranch()) break;
+
 				if (canDeltaRange(newOffset, 33)) {
 					a.adrp(X16, alignedCallback - alignedAddr);
 					a.add(X16, X16, callback & 0xFFF);


### PR DESCRIPTION
1. Fix cbz/cbnz to preserve the sf bit instead of discarding it
2. Remove trampoline creation guard, I'm not sure what purpose it was serving but it was causing the following crashes:

```
== Stack Trace (the most important part) ==
- 0x0
- 0x100f30138 (hook handler)
- Geode.ios.dylib + 0xe899b8 (cocos2d::CCFileUtils::sharedFileUtils() + 0x88)
- Geode.ios.dylib + 0x2b11c (FileUtilsUpdatePaths::sharedFileUtils() + 0x10)
- Geode.ios.dylib + 0x29e54 (geode::modifier::AsStaticFunction_sharedFileUtils<FileUtilsUpdatePaths, cocos2d::CCFileUtils* (*)()>::Impl<cocos2d::CCFileUtils* (*)()>::function() + 0xc)
- 0x100f30138 (hook handler)
- Geode.ios.dylib + 0xe899b8 (cocos2d::CCFileUtils::sharedFileUtils() + 0x88)
- Geode.ios.dylib + 0x306bc (cocos2d::CCFileUtils::get() + 0xc)
```

3. Fix SIGILL on ARM64 caused due to a (newly introduced, in v3.1.12) CBZ/CBNZ relocation being done wrongly if the target address is also relocated; the jump ends up happening to the *original* target address which is a part of the placed hook bytes and thus will always crash. Now we copy the same CBZ/CBNZ instruction and keep it as-is. This fix was applied to other branches too.

The third fix might be tricky and have edge cases, but I did not find any immediate issues in the game.


After 1 and 2 I tested JIT & JITless iOS, opening the game and playing Dash works fine. After 3rd commit I tested only Android64 and it now works fine, but this shouldn't introduce iOS regressions.